### PR TITLE
Update popup_dialog.dart

### DIFF
--- a/lib/src/dialogs/popup_dialog.dart
+++ b/lib/src/dialogs/popup_dialog.dart
@@ -87,17 +87,18 @@ class _ArnaPopupDialog extends StatelessWidget {
               child: ClipRRect(
                 borderRadius: Styles.listBorderRadius,
                 child: ArnaScaffold(
-                  headerBarLeading: headerBarLeading,
-                  title: title,
-                  actions: <Widget>[
-                    if (actions != null)
-                      ...actions!
-                    else
+                  headerBarLeading: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
                       ArnaTextButton(
-                        label: 'Close',
-                        onPressed: Navigator.of(context).pop,
+                        label: MaterialLocalizations.of(context).backButtonTooltip,
+                        onPressed: () => Navigator.pop(context),
                       ),
-                  ],
+                      if (headerBarLeading != null) headerBarLeading!,
+                    ],
+                  ),
+                  title: title,
+                  actions: actions,
                   body: body,
                   isDialog: true,
                 ),

--- a/lib/src/dialogs/popup_dialog.dart
+++ b/lib/src/dialogs/popup_dialog.dart
@@ -90,11 +90,13 @@ class _ArnaPopupDialog extends StatelessWidget {
                   headerBarLeading: headerBarLeading,
                   title: title,
                   actions: <Widget>[
-                    if (actions != null) ...actions!,
-                    ArnaTextButton(
-                      label: 'Close',
-                      onPressed: Navigator.of(context).pop,
-                    ),
+                    if (actions != null)
+                      ...actions!
+                    else
+                      ArnaTextButton(
+                        label: 'Close',
+                        onPressed: Navigator.of(context).pop,
+                      ),
                   ],
                   body: body,
                   isDialog: true,


### PR DESCRIPTION
This PR allows to get rid of "Close" button on the top right of ArnaPopupDialog by making ArnaPopupDialog::actions not null